### PR TITLE
Update frameworks, packages, and DI in project files

### DIFF
--- a/Desktop/Desktop.csproj
+++ b/Desktop/Desktop.csproj
@@ -6,6 +6,8 @@
     <TargetFrameworks>net8.0</TargetFrameworks>
      <!-- <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net8.0-macos</TargetFrameworks> -->
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+    <WindowsSdkPackageVersion Condition="$([MSBuild]::IsOSPlatform('windows'))">10.0.19041.41</WindowsSdkPackageVersion> 
+
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>false</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -42,7 +44,7 @@
 
 
   <ItemGroup>
-	<PackageReference Include="Avalonia.Desktop" Version="11.1.3" />
+	<PackageReference Include="Avalonia.Desktop" Version="11.1.4" />
   </ItemGroup>
 
   	

--- a/KeyVaultExplorer/KeyVaultExplorer.csproj
+++ b/KeyVaultExplorer/KeyVaultExplorer.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+        <WindowsSdkPackageVersion>10.0.19041.41</WindowsSdkPackageVersion> 
+
     <!-- <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net8.0-macos</TargetFrameworks> -->
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
@@ -50,22 +52,22 @@
 
 
   <ItemGroup>
-	<PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.1.3" />
-    <PackageReference Include="Avalonia.Svg.Skia" Version="11.1.0" />
+	<PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.1.4" />
+	<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.4" />
+    <PackageReference Include="Avalonia.Svg.Skia" Version="11.1.0.1" />
     <PackageReference Include="DeviceId" Version="6.7.0" />
     <PackageReference Include="FluentAvaloniaUI" Version="2.1.0" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0-preview.6.24327.7" />
-    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="9.0.0-preview.6.24327.4" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0-preview.6.24327.7" />
-    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.63.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0-rc.1.24431.7" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="9.0.0-rc.1.24451.1" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0-rc.1.24431.7" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.65.3-preview" />
     <PackageReference Include="Azure.ResourceManager.KeyVault" Version="1.3.0" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.6.0" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.6.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlcipher" Version="2.1.9" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlcipher" Version="2.1.10" />
     </ItemGroup>
 
 

--- a/KeyVaultExplorer/Services/ClipboardService.cs
+++ b/KeyVaultExplorer/Services/ClipboardService.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace KeyVaultExplorer.Services;
 
-public class ClipboardService : Avalonia.Input.Platform.IClipboard
+public class ClipboardService
 {
     protected virtual IClipboard? Clipboard => _clipboard ??= Avalonia.Application.Current.GetTopLevel()?.Clipboard;
     private IClipboard? _clipboard;

--- a/KeyVaultExplorer/Services/ServiceCollectionExtension.cs
+++ b/KeyVaultExplorer/Services/ServiceCollectionExtension.cs
@@ -22,7 +22,7 @@ public static class ServiceCollectionExtensions
         collection.AddSingleton<NotificationViewModel>();
         collection.AddSingleton<KvExplorerDb>();
         collection.AddTransient<AppSettingReader>();
-        collection.AddSingleton<IClipboard, ClipboardService>();
-        collection.AddSingleton<IStorageProvider, StorageProviderService>();
+        collection.AddSingleton<ClipboardService>();
+        collection.AddSingleton<StorageProviderService>();
     }
 }

--- a/KeyVaultExplorer/Services/StorageProviderService.cs
+++ b/KeyVaultExplorer/Services/StorageProviderService.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace KeyVaultExplorer.Services;
 
-public class StorageProviderService : Avalonia.Platform.Storage.IStorageProvider
+public class StorageProviderService
 {
     protected virtual IStorageProvider? StorageProvider => _storageProvider ??= Avalonia.Application.Current.GetTopLevel()?.StorageProvider;
     private IStorageProvider? _storageProvider;

--- a/KeyVaultExplorer/ViewModels/PropertiesPageViewModel.cs
+++ b/KeyVaultExplorer/ViewModels/PropertiesPageViewModel.cs
@@ -28,9 +28,9 @@ namespace KeyVaultExplorer.ViewModels;
 public partial class PropertiesPageViewModel : ViewModelBase
 {
     private readonly AuthService _authService;
-    private readonly IClipboard _clipboardService;
+    private readonly ClipboardService _clipboardService;
     private readonly NotificationViewModel _notificationViewModel;
-    private readonly IStorageProvider _storageService;
+    private readonly StorageProviderService _storageService;
     private readonly VaultService _vaultService;
     private SettingsPageViewModel _settingsPageViewModel;
 
@@ -78,8 +78,8 @@ public partial class PropertiesPageViewModel : ViewModelBase
     {
         _vaultService = Defaults.Locator.GetRequiredService<VaultService>();
         _authService = Defaults.Locator.GetRequiredService<AuthService>();
-        _clipboardService = Defaults.Locator.GetRequiredService<IClipboard>();
-        _storageService = Defaults.Locator.GetRequiredService<IStorageProvider>();
+        _clipboardService = Defaults.Locator.GetRequiredService<ClipboardService>();
+        _storageService = Defaults.Locator.GetRequiredService<StorageProviderService>();
     }
 
     public PropertiesPageViewModel(KeyVaultContentsAmalgamation model)
@@ -87,8 +87,8 @@ public partial class PropertiesPageViewModel : ViewModelBase
         _vaultService = Defaults.Locator.GetRequiredService<VaultService>();
         _authService = Defaults.Locator.GetRequiredService<AuthService>();
         _settingsPageViewModel = Defaults.Locator.GetRequiredService<SettingsPageViewModel>();
-        _clipboardService = Defaults.Locator.GetRequiredService<IClipboard>();
-        _storageService = Defaults.Locator.GetRequiredService<IStorageProvider>();
+        _clipboardService = Defaults.Locator.GetRequiredService<ClipboardService>();
+        _storageService = Defaults.Locator.GetRequiredService<StorageProviderService>();  
         _notificationViewModel = new NotificationViewModel();// Defaults.Locator.GetRequiredService<NotificationViewModel>();
         OpenedItem = model;
         Dispatcher.UIThread.InvokeAsync(async () =>

--- a/KeyVaultExplorer/ViewModels/VaultPageViewModel.cs
+++ b/KeyVaultExplorer/ViewModels/VaultPageViewModel.cs
@@ -32,7 +32,7 @@ public partial class VaultPageViewModel : ViewModelBase
 {
     private readonly AuthService _authService;
 
-    private readonly IClipboard _clipboardService;
+    private readonly ClipboardService _clipboardService;
 
     private readonly VaultService _vaultService;
 
@@ -75,7 +75,7 @@ public partial class VaultPageViewModel : ViewModelBase
         _authService = Defaults.Locator.GetRequiredService<AuthService>();
         _settingsPageViewModel = Defaults.Locator.GetRequiredService<SettingsPageViewModel>();
         _notificationViewModel = Defaults.Locator.GetRequiredService<NotificationViewModel>();
-        _clipboardService = Defaults.Locator.GetRequiredService<IClipboard>();
+        _clipboardService = Defaults.Locator.GetRequiredService<ClipboardService>();
         vaultContents = [];
         BitmapImage = new Lazy<Bitmap>(() => LoadImage("avares://KeyVaultExplorer/Assets/AppIcon.ico"));
 

--- a/KeyVaultExplorer/Views/CustomControls/KeyVaultTreeList.axaml
+++ b/KeyVaultExplorer/Views/CustomControls/KeyVaultTreeList.axaml
@@ -178,7 +178,6 @@
                     </Style>
                 </TextBox.Styles>
             </TextBox>
-
         </StackPanel>
 
         <ScrollViewer


### PR DESCRIPTION
- Update frameworks, packages, and DI in project files

- Updated target framework to net8.0 and enabled nullable reference types in Desktop.csproj and KeyVaultExplorer.csproj. Added WindowsSdkPackageVersion to both project files.
- Updated Avalonia.Desktop package in Desktop.csproj to 11.1.4.
- Updated multiple package references in KeyVaultExplorer.csproj to newer versions.
- Modified ClipboardService and StorageProviderService to no longer implement interfaces and updated DI registrations and view models accordingly. 
- Minor layout fix in KeyVaultTreeList.axaml.