### PR TITLE
Smaller enhancements in the secret view

### DIFF
--- a/KeyVaultExplorer/ViewModels/PropertiesPageViewModel.cs
+++ b/KeyVaultExplorer/ViewModels/PropertiesPageViewModel.cs
@@ -306,6 +306,7 @@ public partial class PropertiesPageViewModel : ViewModelBase
 
                 var vm = new CreateNewSecretVersionViewModel();
                 vm.KeyVaultSecretModel = newVersion;
+                vm.SecretValue = (await _vaultService.GetSecret(kvUri: OpenedItem.SecretProperties.VaultUri, secretName: OpenedItem.SecretProperties.Name)).Value;
 
                 var newVersionBtn = new TaskDialogButton("Create Secret", "CreateSecretButtonResult") { IsDefault = true, };
                 newVersionBtn.Bind(TaskDialogButton.IsEnabledProperty, new Binding { Path = "!HasErrors", Mode = BindingMode.OneWay, FallbackValue = false, Source = vm, });

--- a/KeyVaultExplorer/Views/Pages/PropertiesPage.axaml
+++ b/KeyVaultExplorer/Views/Pages/PropertiesPage.axaml
@@ -132,36 +132,48 @@
                     Margin="8,0,8,0"
                     HorizontalAlignment="Stretch"
                     DockPanel.Dock="Top">
-                    <Grid ColumnDefinitions="*,Auto" RowDefinitions="*,*,*">
+                    <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,*,*">
                         <Border
-                            Height="35"
                             Padding="8"
                             Background="{DynamicResource LayerFillColorDefaultBrush}"
                             BorderBrush="{StaticResource ControlElevationBorderBrush}"
                             BorderThickness="1"
                             CornerRadius="4"
                             IsVisible="{Binding IsSecret}">
-                            <Grid ColumnDefinitions="*,Auto" RowDefinitions="*">
+                            <Grid ColumnDefinitions="*,Auto" RowDefinitions="*" VerticalAlignment="Stretch">
+                                <Border
+                                    MaxHeight="200"
+                                    Grid.Column="0"
+                                    IsVisible="True"
+                                    Padding="0"
+                                    BorderThickness="1" 
+                                    CornerRadius="4">
+                                    <ScrollViewer
+                                        VerticalScrollBarVisibility="Visible">
+                                        <StackPanel
+                                            VerticalAlignment="Top">
+                                            <TextBlock
+                                                HorizontalAlignment="Left"
+                                                VerticalAlignment="Center"
+                                                IsVisible="{Binding !#ShowToggleButton.IsChecked}"
+                                                Text="{Binding SecretHidden}" />
+                                            <TextBlock
+                                                HorizontalAlignment="Left"
+                                                VerticalAlignment="Top"
+                                                TextWrapping="Wrap"
+                                                IsVisible="{Binding #ShowToggleButton.IsChecked}"
+                                                Text="{Binding SecretPlainText}" />
+                                        </StackPanel>
 
-                                <TextBlock
-                                    Grid.Column="0"
-                                    HorizontalAlignment="Left"
-                                    VerticalAlignment="Bottom"
-                                    IsVisible="{Binding !#ShowToggleButton.IsChecked}"
-                                    Text="{Binding SecretHidden}" />
-                                <SelectableTextBlock
-                                    Grid.Column="0"
-                                    HorizontalAlignment="Left"
-                                    VerticalAlignment="Center"
-                                    xml:space="preserve"
-                                    IsVisible="{Binding #ShowToggleButton.IsChecked}"
-                                    Text="{Binding SecretPlainText}" />
+                                    </ScrollViewer>
+                                </Border>
+
                                 <ToggleButton
                                     Name="ShowToggleButton"
                                     Grid.Column="1"
                                     Height="30"
                                     HorizontalAlignment="Right"
-                                    VerticalAlignment="Center"
+                                    VerticalAlignment="Top"
                                     Command="{Binding ShouldShowValueCommand}"
                                     CommandParameter="{Binding ShowValue}"
                                     Content="&#xE7B3;"


### PR DESCRIPTION
1. Adding multiline value for secrets
<img width="820" alt="image" src="https://github.com/user-attachments/assets/31f87c5b-6a50-4898-a91b-2389a5c13f54" />

2. On creating a new version, use the secret value of the previous version to edit the value
<img width="439" alt="image" src="https://github.com/user-attachments/assets/05bececf-5a90-4905-87a4-eee048760499" />
