### PR TITLE
#105 Add ability to set custom client id from UI

### DIFF
--- a/Desktop/Desktop.csproj
+++ b/Desktop/Desktop.csproj
@@ -44,8 +44,8 @@
 
 
   <ItemGroup>
-	<PackageReference Include="Avalonia.Desktop" Version="11.2.2" />
-	<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.2" />
+	<PackageReference Include="Avalonia.Desktop" Version="11.2.5" />
+	<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.3" />
   </ItemGroup>
 
   	

--- a/KeyVaultExplorer/KeyVaultExplorer.csproj
+++ b/KeyVaultExplorer/KeyVaultExplorer.csproj
@@ -54,21 +54,21 @@
 
   <ItemGroup>
 	<PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.1.5" />
-	<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.2" />
+	<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.5" />
     <PackageReference Include="Avalonia.Svg.Skia" Version="11.2.0.2" />
-    <PackageReference Include="DeviceId" Version="6.8.0" />
-    <PackageReference Include="FluentAvaloniaUI" Version="2.2.0" />
+    <PackageReference Include="DeviceId" Version="6.9.0" />
+    <PackageReference Include="FluentAvaloniaUI" Version="2.3.0" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.2" />
-    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="9.0.3" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.2" />
-    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.68.0" />
-    <PackageReference Include="Azure.ResourceManager.KeyVault" Version="1.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.70.0" />
+    <PackageReference Include="Azure.ResourceManager.KeyVault" Version="1.3.1" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.7.0" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.7.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlcipher" Version="2.1.10" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlcipher" Version="2.1.11" />
     </ItemGroup>
 
 

--- a/KeyVaultExplorer/Models/AppSettings.cs
+++ b/KeyVaultExplorer/Models/AppSettings.cs
@@ -14,4 +14,9 @@ public class AppSettings
     public string SplitViewDisplayMode { get; set; } = "Inline";
 
     public string PanePlacement { get; set; } = "Left";
+    public bool SettingsPageClientIdCheckbox { get; set; } = false;
+    public string CustomClientId { get; set; } = string.Empty;
+
+
+
 }

--- a/KeyVaultExplorer/Services/AuthService.cs
+++ b/KeyVaultExplorer/Services/AuthService.cs
@@ -28,8 +28,14 @@ public class AuthService
 
     public AuthService()
     {
-        authenticationClient = PublicClientApplicationBuilder.Create(Constants.ClientId)
-            .WithRedirectUri($"msal{Constants.ClientId}://auth")
+
+        var settings = Defaults.Locator.GetRequiredService<AppSettingReader>();
+        var customClientId = (string?)settings.AppSettings.CustomClientId ?? Constants.ClientId;
+        var settingsPageClientIdCheckbox = (bool?)settings.AppSettings.SettingsPageClientIdCheckbox ?? false;
+        string clientId = settingsPageClientIdCheckbox && !string.IsNullOrEmpty(customClientId) ? customClientId : Constants.ClientId;
+
+        authenticationClient = PublicClientApplicationBuilder.Create(clientId)
+            .WithRedirectUri($"msal{clientId}://auth")
             .WithRedirectUri("http://localhost")
             .WithIosKeychainSecurityGroup("us.sidesteplabs.keyvaultexplorer")
             .Build();

--- a/KeyVaultExplorer/ViewModels/SettingsPageViewModel.cs
+++ b/KeyVaultExplorer/ViewModels/SettingsPageViewModel.cs
@@ -45,6 +45,12 @@ public partial class SettingsPageViewModel : ViewModelBase
     [ObservableProperty]
     private ObservableCollection<Settings> settings;
 
+    [ObservableProperty]
+    private bool settingsPageClientIdCheckbox;
+
+    [ObservableProperty]
+    private string customClientId;
+
     public SettingsPageViewModel()
     {
         _authService = Defaults.Locator.GetRequiredService<AuthService>();
@@ -58,7 +64,8 @@ public partial class SettingsPageViewModel : ViewModelBase
             ClearClipboardTimeout = jsonSettings.ClipboardTimeout;
             IsBackgroundTransparencyEnabled = jsonSettings.BackgroundTransparency;
             CurrentAppTheme = jsonSettings.AppTheme ?? "System";
-
+            CustomClientId = jsonSettings.CustomClientId;
+            SettingsPageClientIdCheckbox = jsonSettings.SettingsPageClientIdCheckbox;
             //NavigationLayoutMode = s.NavigationLayoutMode;
         }, DispatcherPriority.MaxValue);
     }
@@ -106,6 +113,26 @@ public partial class SettingsPageViewModel : ViewModelBase
     {
         if (oldValue is not null && oldValue != newValue)
             Dispatcher.UIThread.InvokeAsync(async () => await AddOrUpdateAppSettings(nameof(AppSettings.AppTheme), CurrentAppTheme), DispatcherPriority.Background);
+    }
+
+
+
+    partial void OnSettingsPageClientIdCheckboxChanged(bool value)
+    {
+
+        Dispatcher.UIThread.InvokeAsync(async () => 
+            await AddOrUpdateAppSettings(nameof(AppSettings.SettingsPageClientIdCheckbox), SettingsPageClientIdCheckbox),
+        DispatcherPriority.Background);
+    }
+
+    partial void OnCustomClientIdChanged(string value)
+    {
+        Dispatcher.UIThread.InvokeAsync(async () =>
+        {
+            await Task.Delay(50);
+            await AddOrUpdateAppSettings(nameof(AppSettings.CustomClientId), CustomClientId);
+        },
+         DispatcherPriority.Background);
     }
 
     partial void OnClearClipboardTimeoutChanging(int oldValue, int newValue)

--- a/KeyVaultExplorer/Views/Pages/SettingsPage.axaml
+++ b/KeyVaultExplorer/Views/Pages/SettingsPage.axaml
@@ -8,8 +8,8 @@
     xmlns:ui="using:FluentAvalonia.UI.Controls"
     xmlns:vm="using:KeyVaultExplorer.ViewModels"
     Margin="0,40,0,0"
-    d:DesignHeight="450"
-    d:DesignWidth="880"
+    d:DesignHeight="650"
+    d:DesignWidth="1080"
     x:DataType="vm:SettingsPageViewModel"
     mc:Ignorable="d">
 
@@ -61,6 +61,30 @@
                                 Content="Sign out" />
                         </ui:SettingsExpanderItem.Footer>
                     </ui:SettingsExpanderItem>
+
+                    <ui:SettingsExpanderItem Description="Use a custom Client ID / Application ID for Azure AD authentication">
+                        <ui:SettingsExpanderItem.Content>
+                            <StackPanel Orientation="Horizontal">
+                                <CheckBox Name="SettingsPageClientIdCheckbox" IsChecked="{Binding SettingsPageClientIdCheckbox, Mode=TwoWay}" />
+                                <TextBlock Margin="0,6,0,0">Override Client Id (requires restart)</TextBlock>
+                            </StackPanel>
+                        </ui:SettingsExpanderItem.Content>
+
+                        <ui:SettingsExpanderItem.Footer>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBox
+                                    Name="SettingsPageClientIdTextBox"
+                                    MinWidth="325"
+                                    Classes.clearButton="True"
+                                    IsEnabled="{Binding #SettingsPageClientIdCheckbox.IsChecked}"
+                                    Text="{Binding CustomClientId, Mode=TwoWay}"
+                                    Watermark="Azure Client Id: e.g. 18405e16-1ba4aca2.." />
+                            </StackPanel>
+                        </ui:SettingsExpanderItem.Footer>
+                    </ui:SettingsExpanderItem>
+
+
+
                 </ui:SettingsExpander>
 
                 <ui:SettingsExpander

--- a/KeyVaultExplorer/Views/Pages/SettingsPage.axaml
+++ b/KeyVaultExplorer/Views/Pages/SettingsPage.axaml
@@ -62,7 +62,7 @@
                         </ui:SettingsExpanderItem.Footer>
                     </ui:SettingsExpanderItem>
 
-                    <ui:SettingsExpanderItem Description="Use a custom Client ID / Application ID for Azure AD authentication">
+                    <ui:SettingsExpanderItem Description="Use a custom Client ID / Application ID for Azure MSAL authentication">
                         <ui:SettingsExpanderItem.Content>
                             <StackPanel Orientation="Horizontal">
                                 <CheckBox Name="SettingsPageClientIdCheckbox" IsChecked="{Binding SettingsPageClientIdCheckbox, Mode=TwoWay}" />

--- a/README.md
+++ b/README.md
@@ -82,7 +82,38 @@ Get it from the Microsoft store!
 </p>
 
 
-## First time installs in Azure Tenant:
+## Using your own client id / application Id (your own enterprise application):
+### This requires the check box to be selected, and a valid client id.
+- Create an Enterprise application in your azure AD tenant:
+  <br/>
+![image](https://github.com/user-attachments/assets/c72875a5-ef34-4157-8b2a-bed9f14b4b55)
+<br>
+![image](https://github.com/user-attachments/assets/e0e90e41-c649-4b4a-80a7-74c897ace4bb)
+
+- Select a tenant auth type:
+  <br/>
+![image](https://github.com/user-attachments/assets/f92a9f0b-a6cc-4e47-8f95-a9043e07bf50)
+ - Then navigate to "App Registrations" and go to the "Manage > Authentication" page:
+![image](https://github.com/user-attachments/assets/dadf5b96-6364-41f8-8e2f-e4ea9855c39a)
+- Select Desktop + Devices and add the following, you need to check the following boxes and add `http://localhost` as a custom uri
+![image](https://github.com/user-attachments/assets/3b150988-a189-4429-b29b-b4d4723d6a9e)
+- Add mac redirect uri's:
+![image](https://github.com/user-attachments/assets/43819626-1e95-4de7-8f75-5180761c6eb1)
+- Navigate to the API Permissions section and add the following permissions, you may need an admin to grant consent:
+![image](https://github.com/user-attachments/assets/c20b5e9a-ac23-4710-bc15-a4c5dd9e843e)
+<br/>
+- You or and admin will have to grant consent to your own application if not granted already. 
+![image](https://github.com/user-attachments/assets/8845b9fd-5fed-42a2-bd47-0ab06575c1f0)
+- Open the app and update the client Id, then restart the app: 
+![image](https://github.com/user-attachments/assets/87d75793-5c95-488e-b4d4-20af6b5f46bb)
+- Upon restart you'll see something similar to this:
+  <br/>
+![image](https://github.com/user-attachments/assets/3913632e-0f39-435e-a285-e3ec42975132)
+<br/>
+- Then the app should work as normal under your own identity and your own tenant's enterprise application.
+
+
+## First time installs in Azure Tenant (Using default clientId):
 
 Please follow this Microsoft learn article if you encounter this error: https://learn.microsoft.com/en-us/answers/questions/1393470/azure-enterprise-apps-missing-a-permission-listed
 <p align="left">

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Get it from the Microsoft store!
 
 ## Using your own client id / application Id (your own enterprise application):
 ### This requires the check box to be selected, and a valid client id.
-- Create an Enterprise application in your azure AD tenant:
+- Create an Enterprise application in your Azure AD/Entra tenant:
   <br/>
 ![image](https://github.com/user-attachments/assets/c72875a5-ef34-4157-8b2a-bed9f14b4b55)
 <br>


### PR DESCRIPTION
New feature implementation for enhanced client ID management in the UI, allowing users to use their own enterprise applications, rather than mine from my own tenant. Users will navigate to the settings page, click the checkbox, and add their valid client/application id. 

This implementation has been added in the new version, and has been added to this version as well until the new version is ready. 

This should close #105 
![image](https://github.com/user-attachments/assets/87d75793-5c95-488e-b4d4-20af6b5f46bb)
#### PR Summary
This pull request introduces new properties for managing custom client IDs in the application settings and updates the UI to support these features. It also includes package updates for improved functionality and performance.
- `AppSettings.cs`: Added `SettingsPageClientIdCheckbox` and `CustomClientId` properties.
- `AuthService.cs`: Modified constructor to utilize the new client ID properties.
- `SettingsPageViewModel.cs`: Enhanced with observable properties for the new settings and their change handlers.
- `SettingsPage.axaml`: Updated layout to include a settings expander for custom client ID input.
- `README.md`: Revised to provide instructions for using a custom client ID/application ID in Azure AD.
