### PR TITLE
This adds the ability to add vaults from the same tenant, by subscription id, rg name and vault name, since traversing the dep tree can often not show all the vaults the user has access to.

### DIFF
--- a/KeyVaultExplorer/Views/CustomControls/KeyVaultTreeList.axaml
+++ b/KeyVaultExplorer/Views/CustomControls/KeyVaultTreeList.axaml
@@ -121,6 +121,17 @@
                             UriSource="avares://KeyVaultExplorer/Assets/CollapseAll.png" />
                     </StackPanel>
                 </Button>
+
+                <Button
+                    Margin="5,0,0,0"
+                    VerticalAlignment="Center"
+                    Click="OpenExternalVaultFromUriDialogBox_Click"
+                    Content="&#xE8a7;"
+                    FontFamily="{StaticResource SymbolThemeFontFamily}"
+                    FontSize="16"
+                    Theme="{StaticResource TransparentButton}"
+                    ToolTip.Tip="Open Vault From Uri"
+                    ToolTip.VerticalOffset="10" />
             </StackPanel>
         </Border>
 

--- a/KeyVaultExplorer/Views/Pages/PropertiesDialogs/OpenExternalVault.axaml
+++ b/KeyVaultExplorer/Views/Pages/PropertiesDialogs/OpenExternalVault.axaml
@@ -1,0 +1,36 @@
+<UserControl
+    x:Class="KeyVaultExplorer.OpenExternalVault"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:armmodels="clr-namespace:Azure.ResourceManager.KeyVault;assembly=Azure.ResourceManager.KeyVault"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="clr-namespace:KeyVaultExplorer.Models;assembly=KeyVaultExplorer"
+    xmlns:ui="using:FluentAvalonia.UI.Controls"
+    xmlns:vm="clr-namespace:KeyVaultExplorer.ViewModels"
+    d:DesignHeight="450"
+    d:DesignWidth="600"
+    mc:Ignorable="d">
+
+    <StackPanel Spacing="8">
+        <TextBox
+            Name="SubscriptionId"
+            MinWidth="450"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Stretch"
+            Watermark="Subscription Id e.g. cd7a227e-4..." />
+        <TextBox
+            Name="ResourceGroupName"
+            MinWidth="450"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Stretch"
+            Watermark="Resource Group Name e.g. rg-my-resource-group" />
+        <TextBox
+            Name="VaultName"
+            MinWidth="450"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Stretch"
+            Watermark="Key Vault Name e.g. my-key-vault" />
+    </StackPanel>
+
+</UserControl>

--- a/KeyVaultExplorer/Views/Pages/PropertiesDialogs/OpenExternalVault.axaml.cs
+++ b/KeyVaultExplorer/Views/Pages/PropertiesDialogs/OpenExternalVault.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace KeyVaultExplorer;
+
+public partial class OpenExternalVault : UserControl
+{
+    public OpenExternalVault()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
This adds the ability to add vaults from the same tenant, by subscription id, rg name and vault name, since traversing the dep tree can often not show all the vaults the user has access to. This will also pin the vault as a courtesy. This serves as a solution to #107 until more features in regards to opening vaults, and one off kv values can be implemented. 

The user will still need access to be able to get/list all secrets etc in the vault. 

![image](https://github.com/user-attachments/assets/e795fa3a-7587-4a01-9209-def8409e710e)
![image](https://github.com/user-attachments/assets/447c9733-747b-4b9c-9e3a-0b161012c686)
Error handling:
![image](https://github.com/user-attachments/assets/c0f7ee9c-cda3-406b-b9a6-d34c7092bb05)

