### PR TITLE
v2.1.0 add support for tags editing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -457,3 +457,4 @@ $RECYCLE.BIN/
 /KeyVaultExplorer.Desktop/mac
 /mpdev
 .DS_Store
+/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/msbuild.ps1

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/App.xaml.cs
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/App.xaml.cs
@@ -70,7 +70,7 @@ public partial class App : Application
                                 LogLevel.Error)
 
                         // Default filters for core Uno Platform namespaces
-                        .CoreLogLevel(LogLevel.Warning);
+                        .CoreLogLevel(LogLevel.Critical);
 
 #if DEBUG
                     //Uno Platform namespace filter groups

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/AzureKeyVaultStudio.csproj
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/AzureKeyVaultStudio.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>AzureKeyVaultStudio</AssemblyName>
     <ApplicationId>io.github.cricketthomas.AzureKeyVaultExplorer</ApplicationId>
 
-    <ApplicationDisplayVersion>2.0.5.0</ApplicationDisplayVersion>
+    <ApplicationDisplayVersion>2.1.0.0</ApplicationDisplayVersion>
     <ApplicationVersion>2</ApplicationVersion>
 
     <ApplicationPublisher>cricketthomas</ApplicationPublisher>
@@ -115,6 +115,4 @@
     <PackageReference Include="Uno.CommunityToolkit.WinUI.UI.Controls.DataGrid" />
   </ItemGroup>
 
-
-    
 </Project>

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/AzureKeyVaultStudio.csproj
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/AzureKeyVaultStudio.csproj
@@ -77,10 +77,6 @@
   </PropertyGroup>
 
 
-  <ItemGroup>
-    <None Remove="UserControls\TagsEditor.xaml" />
-  </ItemGroup>
-
 
   <ItemGroup>
     <PackageReference Include="Azure.ResourceManager.KeyVault" />
@@ -120,10 +116,5 @@
   </ItemGroup>
 
 
-  <ItemGroup>
-    <Content Update="Assets\Images\kv-gray-3.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
     
 </Project>

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/AzureKeyVaultStudio.csproj
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/AzureKeyVaultStudio.csproj
@@ -78,6 +78,11 @@
 
 
   <ItemGroup>
+    <None Remove="UserControls\TagsEditor.xaml" />
+  </ItemGroup>
+
+
+  <ItemGroup>
     <PackageReference Include="Azure.ResourceManager.KeyVault" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" />

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Models/KeyVaultValuesAmalgamation.cs
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Models/KeyVaultValuesAmalgamation.cs
@@ -1,10 +1,8 @@
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
-using Azure.ResourceManager.Resources.Models;
 using Azure.Security.KeyVault.Certificates;
 using Azure.Security.KeyVault.Keys;
 using Azure.Security.KeyVault.Secrets;
-using Microsoft.UI.Xaml.XamlTypeInfo;
 
 namespace AzureKeyVaultStudio.Models;
 
@@ -219,9 +217,19 @@ public sealed class KeyVaultItemProperties
         if (EditableTags is null || EditableTags.Count == 0)
             return;
 
+        var seenKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         foreach (var tag in EditableTags)
         {
-            targetTags[tag.Key] = tag.Value;
+            var key = tag.Key?.Trim();
+
+            if (string.IsNullOrWhiteSpace(key))
+                continue;
+
+            if (!seenKeys.Add(key))
+                throw new InvalidOperationException("Duplicate tag keys are not allowed.");
+
+            targetTags[key] = tag.Value;
         }
     }
 }

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Models/KeyVaultValuesAmalgamation.cs
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Models/KeyVaultValuesAmalgamation.cs
@@ -112,15 +112,7 @@ public sealed class KeyVaultItemProperties
         properties.Enabled = Enabled;
         properties.NotBefore = NotBefore;
         properties.ExpiresOn = ExpiresOn;
-
-        if (EditableTags != null)
-        {
-            foreach (var tag in EditableTags)
-            {
-                properties.Tags[tag.Key] = tag.Value;
-            }
-        }
-
+        ApplyEditableTags(properties.Tags);
         return properties;
     }
 
@@ -130,15 +122,7 @@ public sealed class KeyVaultItemProperties
         properties.Enabled = Enabled;
         properties.NotBefore = NotBefore;
         properties.ExpiresOn = ExpiresOn;
-
-        if (EditableTags != null)
-        {
-            foreach (var tag in EditableTags)
-            {
-                properties.Tags[tag.Key] = tag.Value;
-            }
-        }
-
+        ApplyEditableTags(properties.Tags);
         return properties;
     }
 
@@ -146,14 +130,7 @@ public sealed class KeyVaultItemProperties
     {
         var properties = new CertificateProperties(Id);
         properties.Enabled = Enabled;
-        if (EditableTags != null)
-        {
-            foreach (var tag in EditableTags)
-            {
-                properties.Tags[tag.Key] = tag.Value;
-            }
-        }
-
+        ApplyEditableTags(properties.Tags);
         return properties;
     }
 
@@ -235,15 +212,17 @@ public sealed class KeyVaultItemProperties
         
     }
 
-    internal  ObservableCollection<TagItem> FromTagsToEditableTags()
+    private void ApplyEditableTags(IDictionary<string, string> targetTags)
     {
-        var editableTags = new ObservableCollection<TagItem>();
-        if (Tags?.Count > 0)
-            foreach (var item in Tags)
-            {
-                editableTags.Add(new TagItem { Key = item.Key, Value = item.Value });
-            }
-        return editableTags;
+        targetTags.Clear();
+
+        if (EditableTags is null || EditableTags.Count == 0)
+            return;
+
+        foreach (var tag in EditableTags)
+        {
+            targetTags[tag.Key] = tag.Value;
+        }
     }
 }
 

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Models/KeyVaultValuesAmalgamation.cs
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Models/KeyVaultValuesAmalgamation.cs
@@ -1,7 +1,10 @@
+using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
+using Azure.ResourceManager.Resources.Models;
 using Azure.Security.KeyVault.Certificates;
 using Azure.Security.KeyVault.Keys;
 using Azure.Security.KeyVault.Secrets;
+using Microsoft.UI.Xaml.XamlTypeInfo;
 
 namespace AzureKeyVaultStudio.Models;
 
@@ -33,6 +36,7 @@ public sealed class KeyVaultItemProperties
     public string[] TagValues => Tags is not null ? [.. Tags.Values] : [];
     public string[] TagKeys => Tags is not null ? [.. Tags.Keys] : [];
     public string TagValuesString => string.Join(", ", Tags?.Values ?? []);
+    public ObservableCollection<TagItem> EditableTags { get; set; } = new ObservableCollection<TagItem>();
 
     public DateTimeOffset? LastModifiedDate => UpdatedOn.HasValue ? UpdatedOn.Value.ToLocalTime() : CreatedOn?.ToLocalTime();
     public string? WhenLastModified => LastModifiedDate.HasValue ? FormatRelativeDate(LastModifiedDate.Value, true) : null;
@@ -109,9 +113,9 @@ public sealed class KeyVaultItemProperties
         properties.NotBefore = NotBefore;
         properties.ExpiresOn = ExpiresOn;
 
-        if (Tags != null && Tags.Count > 0)
+        if (EditableTags != null)
         {
-            foreach (var tag in Tags)
+            foreach (var tag in EditableTags)
             {
                 properties.Tags[tag.Key] = tag.Value;
             }
@@ -127,9 +131,9 @@ public sealed class KeyVaultItemProperties
         properties.NotBefore = NotBefore;
         properties.ExpiresOn = ExpiresOn;
 
-        if (Tags != null && Tags.Count > 0)
+        if (EditableTags != null)
         {
-            foreach (var tag in Tags)
+            foreach (var tag in EditableTags)
             {
                 properties.Tags[tag.Key] = tag.Value;
             }
@@ -142,9 +146,9 @@ public sealed class KeyVaultItemProperties
     {
         var properties = new CertificateProperties(Id);
         properties.Enabled = Enabled;
-        if (Tags != null && Tags.Count > 0)
+        if (EditableTags != null)
         {
-            foreach (var tag in Tags)
+            foreach (var tag in EditableTags)
             {
                 properties.Tags[tag.Key] = tag.Value;
             }
@@ -188,7 +192,8 @@ public sealed class KeyVaultItemProperties
             RecoveryLevel = recoveryLevel,
             Managed = managed,
             Tags = tags is null ? new Dictionary<string, string>() : new Dictionary<string, string>(tags),
-            Type = type
+            Type = type,
+            EditableTags = tags is null ? []: new ObservableCollection<TagItem>(tags.Select(t => new TagItem { Key = t.Key, Value = t.Value }))
         };
     }
 
@@ -225,6 +230,20 @@ public sealed class KeyVaultItemProperties
             ( < 366, _) => $"{(isPast ? string.Empty : "in ")}{months} {(months == 1 ? "month" : "months")}{(isPast ? " ago" : string.Empty)}",
             (_, _) => $"{(isPast ? string.Empty : "in ")}{years} {(years == 1 ? "year" : "years")}{(isPast ? " ago" : string.Empty)}"
         };
+
+
+        
+    }
+
+    internal  ObservableCollection<TagItem> FromTagsToEditableTags()
+    {
+        var editableTags = new ObservableCollection<TagItem>();
+        if (Tags?.Count > 0)
+            foreach (var item in Tags)
+            {
+                editableTags.Add(new TagItem { Key = item.Key, Value = item.Value });
+            }
+        return editableTags;
     }
 }
 
@@ -234,4 +253,13 @@ public enum KeyVaultItemType
     Secret = 1,
     Key = 2,
     All = 3
+}
+
+public partial class TagItem : ObservableObject
+{
+    [ObservableProperty]
+    public partial string Key { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial string Value { get; set; } = string.Empty;
 }

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Models/KeyVaultValuesAmalgamation.cs
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Models/KeyVaultValuesAmalgamation.cs
@@ -210,7 +210,7 @@ public sealed class KeyVaultItemProperties
         
     }
 
-    private void ApplyEditableTags(IDictionary<string, string> targetTags)
+    public void ApplyEditableTags(IDictionary<string, string> targetTags)
     {
         targetTags.Clear();
 

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Package.appxmanifest
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Package.appxmanifest
@@ -6,7 +6,7 @@
   xmlns:uap18="http://schemas.microsoft.com/appx/manifest/uap/windows10/18"
   IgnorableNamespaces="uap rescap uap18">
 
-  <Identity Version="2.0.5.0" Publisher="CN=FE9032D7-9FA7-4DED-9087-469BC45B4D99" Name="ArthurThomasIV.AzureKeyVaultExplorer-forAzure"/>
+  <Identity Version="2.1.0.0" Publisher="CN=FE9032D7-9FA7-4DED-9087-469BC45B4D99" Name="ArthurThomasIV.AzureKeyVaultExplorer-forAzure"/>
   <Properties>
     <DisplayName>Key Vault Explorer</DisplayName>
     <PublisherDisplayName>Arthur Thomas IV</PublisherDisplayName>

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Presentation/MainViewModel.cs
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Presentation/MainViewModel.cs
@@ -67,7 +67,6 @@ public partial class MainViewModel : ObservableObject
             if (SplitViewWidth != newActual)
             {
                 SplitViewWidth = newActual;
-                OnPropertyChanged(nameof(SplitViewWidth));
             }
         }
     }

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Presentation/MainViewModel.cs
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Presentation/MainViewModel.cs
@@ -7,18 +7,16 @@ namespace AzureKeyVaultStudio.Presentation;
 
 public partial class MainViewModel : ObservableObject
 {
+    private const double PaneMaxWidth = 800;
+    private const double PaneMinWidth = 120;
     private readonly IAuthenticationService _authentication;
+    private readonly AuthService _authService;
+    private readonly IDispatcher _dispatcher;
+    private readonly KeyVaultTreeViewModel _keyVaultTreeViewModel;
     private readonly ILocalSettingsService _localSettings;
     private readonly INavigator _navigator;
-    private readonly IDispatcher _dispatcher;
-    private readonly VaultService _vaultService;
-    private readonly AuthService _authService;
     private readonly IServiceProvider _serviceProvider;
-
-    private readonly KeyVaultTreeViewModel _keyVaultTreeViewModel;
-    public KeyVaultTreeViewModel KeyVaultTreeViewModel => _keyVaultTreeViewModel;
-
-
+    private readonly VaultService _vaultService;
     public MainViewModel(
         IDispatcher dispatcher,
         IStringLocalizer localizer,
@@ -37,7 +35,7 @@ public partial class MainViewModel : ObservableObject
         _dispatcher = dispatcher;
         _vaultService = vaultService;
         _serviceProvider = serviceProvider;
-        keyVaultTreeViewModel.SetDispatcher(dispatcher); // HACK 
+        keyVaultTreeViewModel.SetDispatcher(dispatcher); // HACK
         _keyVaultTreeViewModel = keyVaultTreeViewModel;
         _authService = authService;
 
@@ -56,95 +54,8 @@ public partial class MainViewModel : ObservableObject
         });
     }
 
-    public string? Title { get; }
-
-    public ICommand GoToSecond { get; }
-
-    public ICommand Logout { get; }
-
-    //private async Task GoToSecondView()
-    //{
-    //    await _navigator.NavigateViewModelAsync<SecondViewModel>(this, data: new Entity(Name!));
-    //}
-
-    public async Task DoLogout(CancellationToken token)
-    {
-        await _authentication.LogoutAsync(token);
-    }
-
-    [ObservableProperty]
-    public partial SplitViewDisplayMode SplitViewDisplay { get; set; } = SplitViewDisplayMode.Inline;
-
-    [ObservableProperty]
-    public partial bool IsPaneOpen { get; set; } = true;
-
-    [ObservableProperty]
-    public partial double SplitViewWidth { get; set; } = 220;
-
-    [ObservableProperty]
-    public partial string SearchQuery { get; set; } = string.Empty;
-
-    [ObservableProperty]
-    public partial object? SelectedKeyVaultItem { get; set; }
-
-    [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(IsPaneLeft))]
-    [NotifyPropertyChangedFor(nameof(FontIconType))]
-    public partial SplitViewPanePlacement PanePlacement { get; set; } = SplitViewPanePlacement.Right;
-
-    public bool IsPaneLeft => PanePlacement == SplitViewPanePlacement.Left;
-
     public string FontIconType => PanePlacement == SplitViewPanePlacement.Left ? "\uE8E4" : "\uE8E2";
-    //public FontIcon FontIconType => PanePlacement == SplitViewPanePlacement.Left ? new FontIcon() { Glyph = "&#xE8E4;" } : new FontIcon() { Glyph = "&#xE8E2;" };
-
-    private void LoadSplitViewSettings()
-    {
-        SplitViewDisplay = GetSettingsValue(nameof(SplitViewDisplay), SplitViewDisplayMode.Inline);
-        SplitViewWidth = _localSettings.GetValue(nameof(SplitViewWidth), 300d);
-        IsPaneOpen = _localSettings.GetValue(nameof(IsPaneOpen), true);
-        PanePlacement = GetSettingsValue(nameof(PanePlacement), SplitViewPanePlacement.Right);
-    }
-
-
-
-    [RelayCommand]
-    public void ToggleSplitViewDisplay()
-    {
-        SplitViewDisplay = SplitViewDisplay == SplitViewDisplayMode.Overlay ? SplitViewDisplayMode.Inline : SplitViewDisplayMode.Overlay;
-    }
-
-    [RelayCommand]
-    public void TogglePaneLocation()
-    {
-        PanePlacement = PanePlacement == SplitViewPanePlacement.Right ? SplitViewPanePlacement.Left : SplitViewPanePlacement.Right;
-    }
-
-
-
-    private void Save<T>(string key, T value)
-    {
-        _localSettings.SetValue(key, value);
-    }
-    [RelayCommand]
-    public void SaveAllSettings()
-    {
-        Save(nameof(SplitViewDisplay), SplitViewDisplay.ToString());
-        Save(nameof(SplitViewWidth), SplitViewWidth);
-        Save(nameof(PanePlacement), PanePlacement.ToString());
-        Save(nameof(IsPaneOpen), IsPaneOpen);
-    }
-
-
-    [RelayCommand]
-    public void ClosePane()
-    {
-        IsPaneOpen = false;
-        WeakReferenceMessenger.Default.Send(new PaneStateChangedMessage(false));
-    }
-
-    private const double PaneMinWidth = 100;
-    private const double PaneMaxWidth = 1000;
-
+    public ICommand GoToSecond { get; }
     public double InvertedSplitViewWidth
     {
         get => PaneMaxWidth - (SplitViewWidth - PaneMinWidth);
@@ -160,9 +71,79 @@ public partial class MainViewModel : ObservableObject
             }
         }
     }
+
+    public bool IsPaneLeft => PanePlacement == SplitViewPanePlacement.Left;
+    [ObservableProperty]
+    public partial bool IsPaneOpen { get; set; } = true;
+
+    public KeyVaultTreeViewModel KeyVaultTreeViewModel => _keyVaultTreeViewModel;
+    public ICommand Logout { get; }
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsPaneLeft))]
+    [NotifyPropertyChangedFor(nameof(FontIconType))]
+    public partial SplitViewPanePlacement PanePlacement { get; set; } = SplitViewPanePlacement.Right;
+
+    [ObservableProperty]
+    public partial string SearchQuery { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial object? SelectedKeyVaultItem { get; set; }
+
+    [ObservableProperty]
+    public partial SplitViewDisplayMode SplitViewDisplay { get; set; } = SplitViewDisplayMode.Inline;
+
+    [ObservableProperty]
+    public partial double SplitViewWidth { get; set; } = 220;
+
+    public string? Title { get; }
+    [RelayCommand]
+    public void ClosePane()
+    {
+        IsPaneOpen = false;
+        WeakReferenceMessenger.Default.Send(new PaneStateChangedMessage(false));
+    }
+
+    public async Task DoLogout(CancellationToken token)
+    {
+        await _authentication.LogoutAsync(token);
+    }
+
+    [RelayCommand]
+    public void SaveAllSettings()
+    {
+        Save(nameof(SplitViewDisplay), SplitViewDisplay.ToString());
+        Save(nameof(SplitViewWidth), SplitViewWidth);
+        Save(nameof(PanePlacement), PanePlacement.ToString());
+        Save(nameof(IsPaneOpen), IsPaneOpen);
+    }
+
+    [RelayCommand]
+    public void TogglePaneLocation()
+    {
+        PanePlacement = PanePlacement == SplitViewPanePlacement.Right ? SplitViewPanePlacement.Left : SplitViewPanePlacement.Right;
+    }
+
+    [RelayCommand]
+    public void ToggleSplitViewDisplay()
+    {
+        SplitViewDisplay = SplitViewDisplay == SplitViewDisplayMode.Overlay ? SplitViewDisplayMode.Inline : SplitViewDisplayMode.Overlay;
+    }
+
     private T GetSettingsValue<T>(string key, T defaultValue) where T : struct, Enum
     {
         var stringValue = _localSettings.GetValue(key, defaultValue.ToString());
         return Enum.TryParse<T>(stringValue, out var result) ? result : defaultValue;
+    }
+
+    private void LoadSplitViewSettings()
+    {
+        SplitViewDisplay = GetSettingsValue(nameof(SplitViewDisplay), SplitViewDisplayMode.Inline);
+        SplitViewWidth = _localSettings.GetValue(nameof(SplitViewWidth), 300d);
+        IsPaneOpen = _localSettings.GetValue(nameof(IsPaneOpen), true);
+        PanePlacement = GetSettingsValue(nameof(PanePlacement), SplitViewPanePlacement.Right);
+    }
+    private void Save<T>(string key, T value)
+    {
+        _localSettings.SetValue(key, value);
     }
 }

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Presentation/VaultTabContentPage.xaml
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Presentation/VaultTabContentPage.xaml
@@ -278,12 +278,11 @@
                                                         Height="20"
                                                         MaxWidth="80"
                                                         Padding="5,2"
-                                                        Background="{ThemeResource SystemAccentColor}"
+                                                        Background="{ThemeResource AccentAcrylicBackgroundFillColorDefaultBrush}"
                                                         CornerRadius="2">
                                                         <TextBlock
                                                             VerticalAlignment="Center"
                                                             FontSize="11"
-                                                            Foreground="White"
                                                             IsTextSelectionEnabled="False"
                                                             Text="{x:Bind Mode=OneTime}"
                                                             TextTrimming="CharacterEllipsis" />

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Strings/en/Resources.resw
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Strings/en/Resources.resw
@@ -576,6 +576,9 @@
   <data name="DataGridTextColumnTags.Header" xml:space="preserve">
     <value>Tags</value>
   </data>
+  <data name="TagsHeader.Text" xml:space="preserve">
+    <value>Tags</value>
+  </data>
   <data name="DataGridTextColumnUpdated.Header" xml:space="preserve">
     <value>Updated</value>
   </data>
@@ -668,5 +671,11 @@
   </data>
   <data name="DocumenationHyperlinkButton.Content" xml:space="preserve">
     <value>Documentation: Tenant setup guide</value>
+  </data>
+  <data name="RemoveTagButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Remove Tag</value>
+  </data>
+  <data name="AddTagButton.Content" xml:space="preserve">
+    <value>Add Tag</value>
   </data>
 </root>

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Strings/en/Resources.resw
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Strings/en/Resources.resw
@@ -678,4 +678,7 @@
   <data name="AddTagButton.Content" xml:space="preserve">
     <value>Add Tag</value>
   </data>
+  <data name="CloseButtonText" xml:space="preserve">
+    <value>Close</value>
+  </data>
 </root>

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Strings/es/Resources.resw
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Strings/es/Resources.resw
@@ -678,4 +678,7 @@
   <data name="AddTagButton.Content" xml:space="preserve">
     <value>Agregar etiqueta</value>
   </data>
+  <data name="CloseButtonText" xml:space="preserve">
+    <value>Cerrar</value>
+  </data>
 </root>

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Strings/es/Resources.resw
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Strings/es/Resources.resw
@@ -576,6 +576,9 @@
   <data name="DataGridTextColumnTags.Header" xml:space="preserve">
     <value>Etiquetas</value>
   </data>
+  <data name="TagsHeader.Text" xml:space="preserve">
+    <value>Etiquetas</value>
+  </data>
   <data name="DataGridTextColumnUpdated.Header" xml:space="preserve">
     <value>Actualizado</value>
   </data>
@@ -668,5 +671,11 @@
   </data>
   <data name="DocumenationHyperlinkButton.Content" xml:space="preserve">
     <value>Documentación: Guía de configuración del tenant</value>
+  </data>
+  <data name="RemoveTagButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Eliminar etiqueta</value>
+  </data>
+  <data name="AddTagButton.Content" xml:space="preserve">
+    <value>Agregar etiqueta</value>
   </data>
 </root>

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Strings/fr/Resources.resw
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Strings/fr/Resources.resw
@@ -576,6 +576,9 @@
   <data name="DataGridTextColumnTags.Header" xml:space="preserve">
     <value>Étiquettes</value>
   </data>
+  <data name="TagsHeader.Text" xml:space="preserve">
+    <value>Étiquettes</value>
+  </data>
   <data name="DataGridTextColumnUpdated.Header" xml:space="preserve">
     <value>Mis à jour</value>
   </data>
@@ -668,5 +671,11 @@
   </data>
   <data name="DocumenationHyperlinkButton.Content" xml:space="preserve">
     <value>Documentation : Guide de configuration du tenant</value>
+  </data>
+  <data name="RemoveTagButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Supprimer l’étiquette</value>
+  </data>
+  <data name="AddTagButton.Content" xml:space="preserve">
+    <value>Ajouter étiquette</value>
   </data>
 </root>

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Strings/fr/Resources.resw
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Strings/fr/Resources.resw
@@ -678,4 +678,7 @@
   <data name="AddTagButton.Content" xml:space="preserve">
     <value>Ajouter étiquette</value>
   </data>
+  <data name="CloseButtonText" xml:space="preserve">
+    <value>Fermer</value>
+  </data>
 </root>

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Strings/pt-BR/Resources.resw
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Strings/pt-BR/Resources.resw
@@ -576,6 +576,9 @@
   <data name="DataGridTextColumnTags.Header" xml:space="preserve">
     <value>Tags</value>
   </data>
+  <data name="TagsHeader.Text" xml:space="preserve">
+    <value>Tags</value>
+  </data>
   <data name="DataGridTextColumnUpdated.Header" xml:space="preserve">
     <value>Atualizado</value>
   </data>
@@ -668,5 +671,11 @@
   </data>
   <data name="DocumenationHyperlinkButton.Content" xml:space="preserve">
     <value>Documentação: Guia de configuração do tenant</value>
+  </data>
+  <data name="RemoveTagButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Remover tag</value>
+  </data>
+  <data name="AddTagButton.Content" xml:space="preserve">
+    <value>Adicionar tag</value>
   </data>
 </root>

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Strings/pt-BR/Resources.resw
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/Strings/pt-BR/Resources.resw
@@ -678,4 +678,7 @@
   <data name="AddTagButton.Content" xml:space="preserve">
     <value>Adicionar tag</value>
   </data>
+  <data name="CloseButtonText" xml:space="preserve">
+    <value>Fechar</value>
+  </data>
 </root>

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/ItemDetails.xaml
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/ItemDetails.xaml
@@ -20,16 +20,6 @@
     d:DesignWidth="400"
     mc:Ignorable="d skia">
 
-    <UserControl.Resources>
-        <UniformGridLayout
-            x:Key="UniformGridLayout2"
-            MinColumnSpacing="12"
-            MinItemHeight="108"
-            MinItemWidth="108"
-            MinRowSpacing="12" />
-
-    </UserControl.Resources>
-
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid.Resources>
@@ -47,12 +37,6 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-
-        <!--<local:OverrideTitlebar
-            Name="OverrideTitlebar"
-            Grid.Row="0"
-            skia:Visibility="Collapsed"
-            SecondaryTitle="{x:Bind ViewModel.OpenedItem.Name, Mode=OneWay}" />-->
 
         <CommandBar
             Grid.Row="0"

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/ItemDetails.xaml
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/ItemDetails.xaml
@@ -20,6 +20,15 @@
     d:DesignWidth="400"
     mc:Ignorable="d skia">
 
+    <UserControl.Resources>
+        <UniformGridLayout
+            x:Key="UniformGridLayout2"
+            MinColumnSpacing="12"
+            MinItemHeight="108"
+            MinItemWidth="108"
+            MinRowSpacing="12" />
+
+    </UserControl.Resources>
 
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
@@ -313,29 +322,29 @@
                             Text="{x:Bind ViewModel.OpenedItem.UpdatedOn, Mode=OneWay}" />
                     </Grid>
 
-                    <ItemsControl Margin="0,4,0,0" ItemsSource="{x:Bind ViewModel.OpenedItem.TagValues, Mode=OneWay}">
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <StackPanel Orientation="Horizontal" Spacing="4" />
-                            </ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate x:DataType="x:String">
+                    <ItemsRepeater Margin="0,4,0,0" ItemsSource="{x:Bind ViewModel.OpenedItem.EditableTags, Mode=OneWay}">
+                        <ItemsRepeater.Layout>
+                            <toolkit:WrapLayout HorizontalSpacing="5" VerticalSpacing="5" />
+                        </ItemsRepeater.Layout>
+
+                        <ItemsRepeater.ItemTemplate>
+                            <DataTemplate x:DataType="models:TagItem">
                                 <Border
                                     Height="18"
                                     Padding="6,2"
-                                    Background="{ThemeResource SystemAccentColor}"
+                                    Background="{ThemeResource AccentAcrylicBackgroundFillColorBaseBrush}"
                                     CornerRadius="2">
                                     <TextBlock
+                                        x:Name="textBlock"
                                         FontSize="10"
                                         Foreground="White"
                                         IsTextSelectionEnabled="True"
-                                        Text="{x:Bind Mode=OneTime}"
+                                        Text="{x:Bind sys:String.Format(x:Null, '{0}: {1}', Key, Value)}"
                                         TextTrimming="CharacterEllipsis" />
                                 </Border>
                             </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
+                        </ItemsRepeater.ItemTemplate>
+                    </ItemsRepeater>
                 </StackPanel>
             </Border>
 

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/ItemDetails.xaml
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/ItemDetails.xaml
@@ -119,7 +119,7 @@
 
                 <Border
                     Grid.Column="0"
-                    MaxHeight="120"
+                    MaxHeight="150"
                     Padding="8,6"
                     Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/ItemDetails.xaml
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/ItemDetails.xaml
@@ -55,12 +55,20 @@
                 <AppBarButton
                     x:Uid="ItemDetailsOpenAppBarButton"
                     Command="{x:Bind ViewModel.OpenInAzureCommand, Mode=OneWay}"
-                    Icon="OpenFile" />
+                    Icon="OpenFile">
+                    <AppBarButton.KeyboardAccelerators>
+                        <KeyboardAccelerator Key="O" Modifiers="Control" />
+                    </AppBarButton.KeyboardAccelerators>
+                </AppBarButton>
 
                 <AppBarButton
                     x:Uid="ItemDetailsRefreshAppBarButton"
                     Command="{x:Bind ViewModel.RefreshCommand, Mode=OneWay}"
-                    Icon="Refresh" />
+                    Icon="Refresh">
+                    <AppBarButton.KeyboardAccelerators>
+                        <KeyboardAccelerator Key="F5" />
+                    </AppBarButton.KeyboardAccelerators>
+                </AppBarButton>
                 <AppBarButton
                     x:Uid="ItemDetailsCopyAppBarButton"
                     Command="{x:Bind ViewModel.CopyCommand, Mode=OneWay}"

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/ItemDetails.xaml
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/ItemDetails.xaml
@@ -332,12 +332,11 @@
                                 <Border
                                     Height="18"
                                     Padding="6,2"
-                                    Background="{ThemeResource AccentAcrylicBackgroundFillColorBaseBrush}"
+                                    Background="{ThemeResource AccentAcrylicBackgroundFillColorDefaultBrush}"
                                     CornerRadius="2">
                                     <TextBlock
                                         x:Name="textBlock"
                                         FontSize="10"
-                                        Foreground="White"
                                         IsTextSelectionEnabled="True"
                                         Text="{x:Bind sys:String.Format(x:Null, '{0}: {1}', Key, Value)}"
                                         TextTrimming="CharacterEllipsis" />

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/NewItem.xaml
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/NewItem.xaml
@@ -121,7 +121,6 @@
                 <StackPanel Orientation="Vertical" Spacing="4">
                     <TextBlock x:Uid="SecretValueTextBlock" />
 
-
                     <Grid ColumnSpacing="4">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
@@ -144,6 +143,8 @@
 
                 </StackPanel>
 
+
+                <local:TagsEditor Tag="{x:Bind ViewModel.ItemPropertiesModel.Tags, Mode=TwoWay}" />
             </StackPanel>
         </ScrollViewer>
 

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/NewItem.xaml
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/NewItem.xaml
@@ -128,7 +128,8 @@
                         <TextBox
                             x:Name="SecretValueTextbox"
                             x:Uid="SecretValueTextbox"
-                            Height="100"
+                            MinHeight="100"
+                            MaxHeight="250"
                             AcceptsReturn="True"
                             Text="{x:Bind ViewModel.SecretValue, Mode=TwoWay}"
                             TextWrapping="Wrap" />

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/NewItem.xaml
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/NewItem.xaml
@@ -5,7 +5,6 @@
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:AzureKeyVaultStudio.UserControls"
-    xmlns:localx="AzureKeyVaultStudio.UserControls.NewItem"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:skia="http://uno.ui/skia"
     d:DesignHeight="300"
@@ -144,7 +143,8 @@
                 </StackPanel>
 
 
-                <local:TagsEditor Tag="{x:Bind ViewModel.ItemPropertiesModel.Tags, Mode=TwoWay}" />
+                <local:TagsEditor EditableTags="{x:Bind ViewModel.ItemPropertiesModel.EditableTags, Mode=TwoWay}" />
+
             </StackPanel>
         </ScrollViewer>
 

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/NewItem.xaml.cs
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/NewItem.xaml.cs
@@ -31,7 +31,7 @@ public sealed partial class NewItem : UserControl
     {
         WeakReferenceMessenger.Default.Register<ShowValidationErrorMessage, Guid>(this, ViewModel.MessengerToken, async (r, m) =>
         {
-            ShowDialogMessage(_localizer["NewItemErrorTitle"], m.Data, _localizer["NewItemDismissButtonText"]);
+            ShowDialogMessage(_localizer["NewItemErrorTitle"], m.Data, _localizer["NewItemDismissButtonText"], true);
         });
         WeakReferenceMessenger.Default.Register<ShowSuccessOperationMessage, Guid>(this, ViewModel.MessengerToken, async (r, m) =>
         {
@@ -41,7 +41,7 @@ public sealed partial class NewItem : UserControl
         });
     }
 
-    private void ShowDialogMessage(string title, string message, string dismissButtonText)
+    private void ShowDialogMessage(string title, string message, string dismissMessageButtonText, bool isError = false)
     {
         _ = DispatcherQueue.TryEnqueue(async () =>
         {
@@ -62,10 +62,16 @@ public sealed partial class NewItem : UserControl
                     HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
                     MaxHeight = 300
                 },
-                CloseButtonText = "OK",
+               
+                CloseButtonText = _localizer?["CloseButtonText"] ?? "Close",
                 XamlRoot = this.XamlRoot,
                 RequestedTheme = this.ActualTheme,
             };
+
+            if (isError)
+            {
+                contentDialog.PrimaryButtonText = dismissMessageButtonText ?? "OK";
+            }
             contentDialog.CloseButtonClick += ContentDialog_CloseButtonClick;
             await contentDialog.ShowAsync();
         });

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/NewItem.xaml.cs
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/NewItem.xaml.cs
@@ -63,16 +63,22 @@ public sealed partial class NewItem : UserControl
                     MaxHeight = 300
                 },
                
-                CloseButtonText = _localizer?["CloseButtonText"] ?? "Close",
                 XamlRoot = this.XamlRoot,
                 RequestedTheme = this.ActualTheme,
             };
 
+
+            // allow users to dismiss only if its an error alert, they can still close the window via parent. 
+            // otherwise, show just the close button since users are done with the window and we dont support creating multiple secrets aat a time, yet
             if (isError)
             {
                 contentDialog.PrimaryButtonText = dismissMessageButtonText ?? "OK";
             }
-            contentDialog.CloseButtonClick += ContentDialog_CloseButtonClick;
+            else
+            {
+                contentDialog.CloseButtonText = _localizer?["CloseButtonText"] ?? "Close";
+                contentDialog.CloseButtonClick += ContentDialog_CloseButtonClick;
+            }
             await contentDialog.ShowAsync();
         });
     }

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/NewVersionDialog.xaml
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/NewVersionDialog.xaml
@@ -8,7 +8,7 @@
     RequestedTheme="Default"
     Style="{ThemeResource DefaultContentDialogStyle}">
     <ScrollViewer
-        MinWidth="400"
+        MinWidth="500"
         HorizontalAlignment="Stretch"
         VerticalAlignment="Stretch">
 

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/NewVersionDialog.xaml
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/NewVersionDialog.xaml
@@ -110,6 +110,8 @@
                     Text="{x:Bind ViewModel.SecretValue, Mode=TwoWay}"
                     TextWrapping="Wrap" />
             </StackPanel>
+
+            <local:TagsEditor EditableTags="{x:Bind ViewModel.ItemPropertiesModel.EditableTags, Mode=TwoWay}" />
         </StackPanel>
     </ScrollViewer>
 </ContentDialog>

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/NewVersionDialog.xaml
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/NewVersionDialog.xaml
@@ -103,7 +103,8 @@
                     Text="Secret Value" />
                 <TextBox
                     x:Name="SecretValueTextbox"
-                    Height="100"
+                    MinHeight="100"
+                    MaxHeight="250"
                     AcceptsReturn="True"
                     IsEnabled="{x:Bind ViewModel.IsEdit, Converter={StaticResource EmptyStringToObjectConverter}}"
                     PlaceholderText="Enter the secret"

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/TagsEditor.xaml
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/TagsEditor.xaml
@@ -5,6 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:AzureKeyVaultStudio.UserControls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="using:AzureKeyVaultStudio.Models"
     xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     d:DesignHeight="300"
     d:DesignWidth="400"
@@ -21,7 +22,7 @@
                 Orientation="Vertical"
                 Spacing="8" />
 
-            <DataTemplate x:Key="TagsTemplateBase" x:DataType="local:TagItem">
+            <DataTemplate x:Key="TagsTemplateBase" x:DataType="models:TagItem">
                 <Grid ColumnSpacing="10">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="200" />
@@ -30,23 +31,25 @@
                     </Grid.ColumnDefinitions>
                     <TextBox
                         HorizontalAlignment="Stretch"
+                        AcceptsReturn="False"
                         MaxLength="512"
                         PlaceholderText="Key"
                         Text="{x:Bind Key, Mode=TwoWay}" />
                     <TextBox
                         Grid.Column="1"
                         HorizontalAlignment="Stretch"
+                        AcceptsReturn="False"
                         MaxLength="256"
                         PlaceholderText="Value"
                         Text="{x:Bind Value, Mode=TwoWay}" />
                 </Grid>
             </DataTemplate>
 
-            <DataTemplate x:Key="TagsTemplate" x:DataType="local:TagItem">
-                <Grid ColumnSpacing="10">
+            <DataTemplate x:Key="TagsTemplate" x:DataType="models:TagItem">
+                <Grid ColumnSpacing="4">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="200" />
-                        <ColumnDefinition Width="200" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
 
@@ -66,14 +69,16 @@
                         CommandParameter="{x:Bind}"
                     -->
                     <Button
+                        x:Uid="RemoveTagButton"
                         Grid.Column="2"
                         Margin="8,0,0,0"
                         VerticalAlignment="Center"
+                        Background="Transparent"
+                        BorderBrush="Transparent"
                         Click="RemoveTagButton_Click"
                         CommandParameter="{x:Bind}"
                         Content="&#xE74D;"
-                        FontFamily="Segoe Fluent Icons"
-                        Foreground="{ThemeResource SystemFillColorCriticalBrush}" />
+                        FontFamily="Segoe Fluent Icons" />
                 </Grid>
             </DataTemplate>
         </ResourceDictionary>
@@ -84,16 +89,24 @@
         HorizontalScrollBarVisibility="Auto"
         HorizontalScrollMode="Auto"
         IsVerticalScrollChainingEnabled="False">
-        <Grid>
+        <Grid RowSpacing="4">
             <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
-            <Button
+
+            <TextBlock
+                x:Uid="TagsHeader"
                 Grid.Row="0"
+                Margin="0,0,0,8"
+                FontSize="14" />
+            <Button
+                x:Uid="AddTagButton"
+                Grid.Row="0"
+                Padding="8,3"
                 HorizontalAlignment="Right"
-                Click="Button_Click"
-                Content="Add Tags" />
+                Click="AddTagButton_Click" />
 
             <ItemsRepeater
                 Grid.Row="1"

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/TagsEditor.xaml
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/TagsEditor.xaml
@@ -21,7 +21,7 @@
                 x:Key="VerticalStackLayout"
                 x:Name="VerticalStackLayout"
                 Orientation="Vertical"
-                Spacing="8" />
+                Spacing="6" />
 
             <DataTemplate x:Key="TagsTemplate" x:DataType="models:TagItem">
                 <Grid skia:Margin="0,4,0,4" ColumnSpacing="4">
@@ -42,6 +42,7 @@
                         Grid.Column="1"
                         HorizontalAlignment="Stretch"
                         AcceptsReturn="False"
+                        IsTabStop="True"
                         MaxLength="256"
                         PlaceholderText="Value"
                         Text="{x:Bind Value, Mode=TwoWay}" />
@@ -49,8 +50,7 @@
                     <Button
                         x:Uid="RemoveTagButton"
                         Grid.Column="2"
-                        Margin="8,0,0,0"
-                        VerticalAlignment="Center"
+                        VerticalAlignment="Bottom"
                         Background="Transparent"
                         BorderBrush="Transparent"
                         Click="RemoveTagButton_Click"
@@ -62,6 +62,7 @@
         </ResourceDictionary>
 
     </UserControl.Resources>
+
 
 
     <ScrollViewer
@@ -80,14 +81,14 @@
 
             <TextBlock
                 x:Uid="TagsHeader"
-                Grid.Row="1"
+                Grid.Row="0"
                 Margin="0,0,0,8"
                 FontSize="14" />
             <Button
                 x:Uid="AddTagButton"
                 Grid.Row="1"
                 Padding="8,3"
-                HorizontalAlignment="Right"
+                HorizontalAlignment="Left"
                 Click="AddTagButton_Click" />
 
             <ItemsRepeater
@@ -95,7 +96,8 @@
                 HorizontalAlignment="Stretch"
                 win:Layout="{StaticResource VerticalStackLayout}"
                 ItemTemplate="{StaticResource TagsTemplate}"
-                ItemsSource="{x:Bind EditableTags, Mode=OneWay}" />
+                ItemsSource="{x:Bind EditableTags, Mode=OneWay}"
+                TabFocusNavigation="Local" />
         </Grid>
     </ScrollViewer>
 </UserControl>

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/TagsEditor.xaml
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/TagsEditor.xaml
@@ -22,29 +22,6 @@
                 Orientation="Vertical"
                 Spacing="8" />
 
-            <DataTemplate x:Key="TagsTemplateBase" x:DataType="models:TagItem">
-                <Grid ColumnSpacing="10">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="200" />
-                        <ColumnDefinition Width="200" />
-                        <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
-                    <TextBox
-                        HorizontalAlignment="Stretch"
-                        AcceptsReturn="False"
-                        MaxLength="512"
-                        PlaceholderText="Key"
-                        Text="{x:Bind Key, Mode=TwoWay}" />
-                    <TextBox
-                        Grid.Column="1"
-                        HorizontalAlignment="Stretch"
-                        AcceptsReturn="False"
-                        MaxLength="256"
-                        PlaceholderText="Value"
-                        Text="{x:Bind Value, Mode=TwoWay}" />
-                </Grid>
-            </DataTemplate>
-
             <DataTemplate x:Key="TagsTemplate" x:DataType="models:TagItem">
                 <Grid ColumnSpacing="4">
                     <Grid.ColumnDefinitions>
@@ -55,19 +32,19 @@
 
                     <TextBox
                         HorizontalAlignment="Stretch"
+                        AcceptsReturn="False"
+                        MaxLength="256"
                         PlaceholderText="Key"
                         Text="{x:Bind Key, Mode=TwoWay}" />
 
                     <TextBox
                         Grid.Column="1"
                         HorizontalAlignment="Stretch"
+                        AcceptsReturn="False"
+                        MaxLength="256"
                         PlaceholderText="Value"
                         Text="{x:Bind Value, Mode=TwoWay}" />
 
-                    <!--
-                        Command="{Binding DataContext.RemoveTagCommand, ElementName=TagsEditorRoot}"
-                        CommandParameter="{x:Bind}"
-                    -->
                     <Button
                         x:Uid="RemoveTagButton"
                         Grid.Column="2"
@@ -85,31 +62,35 @@
 
     </UserControl.Resources>
 
+
     <ScrollViewer
         HorizontalScrollBarVisibility="Auto"
         HorizontalScrollMode="Auto"
         IsVerticalScrollChainingEnabled="False">
+
         <Grid RowSpacing="4">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
+            <Border BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" BorderThickness="0,1,0,0" />
 
             <TextBlock
                 x:Uid="TagsHeader"
-                Grid.Row="0"
+                Grid.Row="1"
                 Margin="0,0,0,8"
                 FontSize="14" />
             <Button
                 x:Uid="AddTagButton"
-                Grid.Row="0"
+                Grid.Row="1"
                 Padding="8,3"
                 HorizontalAlignment="Right"
                 Click="AddTagButton_Click" />
 
             <ItemsRepeater
-                Grid.Row="1"
+                Grid.Row="2"
                 HorizontalAlignment="Stretch"
                 ItemTemplate="{StaticResource TagsTemplate}"
                 ItemsSource="{x:Bind EditableTags, Mode=OneWay}"

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/TagsEditor.xaml
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/TagsEditor.xaml
@@ -19,7 +19,6 @@
             </ResourceDictionary.MergedDictionaries>
             <win:StackLayout
                 x:Key="VerticalStackLayout"
-                x:Name="VerticalStackLayout"
                 Orientation="Vertical"
                 Spacing="6" />
 

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/TagsEditor.xaml
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/TagsEditor.xaml
@@ -6,24 +6,25 @@
     xmlns:local="using:AzureKeyVaultStudio.UserControls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:models="using:AzureKeyVaultStudio.Models"
+    xmlns:skia="http://uno.ui/not_win"
     xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     d:DesignHeight="300"
     d:DesignWidth="400"
-    mc:Ignorable="d">
+    mc:Ignorable="d skia">
     <UserControl.Resources>
 
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <win:ResourceDictionary Source="ms-appx:///Microsoft.UI.Xaml/DensityStyles/Compact.xaml" />
             </ResourceDictionary.MergedDictionaries>
-            <StackLayout
+            <win:StackLayout
                 x:Key="VerticalStackLayout"
                 x:Name="VerticalStackLayout"
                 Orientation="Vertical"
                 Spacing="8" />
 
             <DataTemplate x:Key="TagsTemplate" x:DataType="models:TagItem">
-                <Grid ColumnSpacing="4">
+                <Grid skia:Margin="0,4,0,4" ColumnSpacing="4">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="*" />
@@ -92,9 +93,9 @@
             <ItemsRepeater
                 Grid.Row="2"
                 HorizontalAlignment="Stretch"
+                win:Layout="{StaticResource VerticalStackLayout}"
                 ItemTemplate="{StaticResource TagsTemplate}"
-                ItemsSource="{x:Bind EditableTags, Mode=OneWay}"
-                Layout="{StaticResource VerticalStackLayout}" />
+                ItemsSource="{x:Bind EditableTags, Mode=OneWay}" />
         </Grid>
     </ScrollViewer>
 </UserControl>

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/TagsEditor.xaml
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/TagsEditor.xaml
@@ -1,0 +1,106 @@
+﻿<UserControl
+    x:Class="AzureKeyVaultStudio.UserControls.TagsEditor"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:AzureKeyVaultStudio.UserControls"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    d:DesignHeight="300"
+    d:DesignWidth="400"
+    mc:Ignorable="d">
+    <UserControl.Resources>
+
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <win:ResourceDictionary Source="ms-appx:///Microsoft.UI.Xaml/DensityStyles/Compact.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+            <StackLayout
+                x:Key="VerticalStackLayout"
+                x:Name="VerticalStackLayout"
+                Orientation="Vertical"
+                Spacing="8" />
+
+            <DataTemplate x:Key="TagsTemplateBase" x:DataType="local:TagItem">
+                <Grid ColumnSpacing="10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="200" />
+                        <ColumnDefinition Width="200" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBox
+                        HorizontalAlignment="Stretch"
+                        MaxLength="512"
+                        PlaceholderText="Key"
+                        Text="{x:Bind Key, Mode=TwoWay}" />
+                    <TextBox
+                        Grid.Column="1"
+                        HorizontalAlignment="Stretch"
+                        MaxLength="256"
+                        PlaceholderText="Value"
+                        Text="{x:Bind Value, Mode=TwoWay}" />
+                </Grid>
+            </DataTemplate>
+
+            <DataTemplate x:Key="TagsTemplate" x:DataType="local:TagItem">
+                <Grid ColumnSpacing="10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="200" />
+                        <ColumnDefinition Width="200" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBox
+                        HorizontalAlignment="Stretch"
+                        PlaceholderText="Key"
+                        Text="{x:Bind Key, Mode=TwoWay}" />
+
+                    <TextBox
+                        Grid.Column="1"
+                        HorizontalAlignment="Stretch"
+                        PlaceholderText="Value"
+                        Text="{x:Bind Value, Mode=TwoWay}" />
+
+                    <!--
+                        Command="{Binding DataContext.RemoveTagCommand, ElementName=TagsEditorRoot}"
+                        CommandParameter="{x:Bind}"
+                    -->
+                    <Button
+                        Grid.Column="2"
+                        Margin="8,0,0,0"
+                        VerticalAlignment="Center"
+                        Click="RemoveTagButton_Click"
+                        CommandParameter="{x:Bind}"
+                        Content="&#xE74D;"
+                        FontFamily="Segoe Fluent Icons"
+                        Foreground="{ThemeResource SystemFillColorCriticalBrush}" />
+                </Grid>
+            </DataTemplate>
+        </ResourceDictionary>
+
+    </UserControl.Resources>
+
+    <ScrollViewer
+        HorizontalScrollBarVisibility="Auto"
+        HorizontalScrollMode="Auto"
+        IsVerticalScrollChainingEnabled="False">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <Button
+                Grid.Row="0"
+                HorizontalAlignment="Right"
+                Click="Button_Click"
+                Content="Add Tags" />
+
+            <ItemsRepeater
+                Grid.Row="1"
+                HorizontalAlignment="Stretch"
+                ItemTemplate="{StaticResource TagsTemplate}"
+                ItemsSource="{x:Bind EditableTags, Mode=OneWay}"
+                Layout="{StaticResource VerticalStackLayout}" />
+        </Grid>
+    </ScrollViewer>
+</UserControl>

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/TagsEditor.xaml.cs
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/TagsEditor.xaml.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace AzureKeyVaultStudio.UserControls;
+
+public sealed partial class TagsEditor : UserControl
+{
+
+    
+    public ObservableCollection<TagItem> EditableTags { get; } = new();
+
+    public TagsEditor()
+    {
+        this.InitializeComponent();
+        TranformTagsToTagItems();
+
+        EditableTags.CollectionChanged += EditableTagsUpdateBindingTags_CollectionChanged;
+    }
+
+    private void EditableTagsUpdateBindingTags_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+    {
+        Dictionary<string, string>? dictTags = [];
+        foreach(var tag in EditableTags)
+        {
+            dictTags.Add(tag.Key, tag.Value);
+        }
+    }
+
+    //public static readonly DependencyProperty RemoveTagCommandProperty = DependencyProperty.Register(
+    // nameof(RemoveTagCommand),
+    // typeof(ICommand),
+    // typeof(TagsEditor),
+    // new PropertyMetadata(default));
+
+    //public ICommand RemoveTagCommand
+    //{
+    //    get => (ICommand)GetValue(RemoveTagCommandProperty);
+    //    set => SetValue(RemoveTagCommandProperty, value);
+    //}
+
+
+    public static readonly DependencyProperty TagsProperty =
+        DependencyProperty.Register(
+            nameof(Tags),
+            typeof(Dictionary<string, string>),
+            typeof(TagsEditor),
+            new PropertyMetadata(default(TagsEditor)));
+
+    public Dictionary<string, string> Tags
+    {
+        get => (Dictionary<string, string>)GetValue(TagsProperty);
+        set => SetValue(TagsProperty, value);
+    }
+
+    private void RemoveTagButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button button && button.CommandParameter is TagItem tagItem)
+        {
+            EditableTags.Remove(tagItem);
+        }
+    }
+
+    private void Button_Click(object sender, RoutedEventArgs e)
+    {
+        var count = EditableTags is null ? 0 : EditableTags.Count;
+        EditableTags.Add(new TagItem
+        {
+            Key = $"Key{count}",
+            Value = $"Value{count}"
+        });
+    }
+
+    private void TranformTagsToTagItems()
+    {
+        foreach(var item in Tags)
+        {
+            EditableTags.Add(new TagItem { Key = item.Key, Value = item.Value });
+        }
+    }
+
+}
+
+public partial class TagItem : ObservableObject
+{
+    [ObservableProperty]
+    public partial string Key { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial string Value { get; set; } = string.Empty;
+}

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/TagsEditor.xaml.cs
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/TagsEditor.xaml.cs
@@ -1,18 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
@@ -24,10 +10,9 @@ public sealed partial class TagsEditor : UserControl
     public TagsEditor()
     {
         this.InitializeComponent();
-        if(EditableTags is null)
-        {
+
+        if (EditableTags is null)
             EditableTags = [];
-        }
     }
 
   
@@ -55,7 +40,6 @@ public sealed partial class TagsEditor : UserControl
 
     private void AddTagButton_Click(object sender, RoutedEventArgs e)
     {
-        var count = EditableTags is null ? 0 : EditableTags.Count;
         EditableTags.Add(new TagItem { Key = string.Empty, Value = string.Empty });
     }
  

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/TagsEditor.xaml.cs
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/TagsEditor.xaml.cs
@@ -21,50 +21,28 @@ namespace AzureKeyVaultStudio.UserControls;
 public sealed partial class TagsEditor : UserControl
 {
 
-    
-    public ObservableCollection<TagItem> EditableTags { get; } = new();
-
     public TagsEditor()
     {
         this.InitializeComponent();
-        TranformTagsToTagItems();
-
-        EditableTags.CollectionChanged += EditableTagsUpdateBindingTags_CollectionChanged;
-    }
-
-    private void EditableTagsUpdateBindingTags_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-    {
-        Dictionary<string, string>? dictTags = [];
-        foreach(var tag in EditableTags)
+        if(EditableTags is null)
         {
-            dictTags.Add(tag.Key, tag.Value);
+            EditableTags = [];
         }
     }
 
-    //public static readonly DependencyProperty RemoveTagCommandProperty = DependencyProperty.Register(
-    // nameof(RemoveTagCommand),
-    // typeof(ICommand),
-    // typeof(TagsEditor),
-    // new PropertyMetadata(default));
+  
 
-    //public ICommand RemoveTagCommand
-    //{
-    //    get => (ICommand)GetValue(RemoveTagCommandProperty);
-    //    set => SetValue(RemoveTagCommandProperty, value);
-    //}
-
-
-    public static readonly DependencyProperty TagsProperty =
+    public static readonly DependencyProperty EditableTagsProperty =
         DependencyProperty.Register(
-            nameof(Tags),
-            typeof(Dictionary<string, string>),
+            nameof(EditableTags),
+            typeof(ObservableCollection<TagItem>),
             typeof(TagsEditor),
             new PropertyMetadata(default(TagsEditor)));
 
-    public Dictionary<string, string> Tags
+    public ObservableCollection<TagItem> EditableTags
     {
-        get => (Dictionary<string, string>)GetValue(TagsProperty);
-        set => SetValue(TagsProperty, value);
+        get => (ObservableCollection<TagItem>)GetValue(EditableTagsProperty);
+        set => SetValue(EditableTagsProperty, value);
     }
 
     private void RemoveTagButton_Click(object sender, RoutedEventArgs e)
@@ -75,31 +53,12 @@ public sealed partial class TagsEditor : UserControl
         }
     }
 
-    private void Button_Click(object sender, RoutedEventArgs e)
+    private void AddTagButton_Click(object sender, RoutedEventArgs e)
     {
         var count = EditableTags is null ? 0 : EditableTags.Count;
-        EditableTags.Add(new TagItem
-        {
-            Key = $"Key{count}",
-            Value = $"Value{count}"
-        });
+        EditableTags.Add(new TagItem { Key = string.Empty, Value = string.Empty });
     }
-
-    private void TranformTagsToTagItems()
-    {
-        foreach(var item in Tags)
-        {
-            EditableTags.Add(new TagItem { Key = item.Key, Value = item.Value });
-        }
-    }
+ 
 
 }
 
-public partial class TagItem : ObservableObject
-{
-    [ObservableProperty]
-    public partial string Key { get; set; } = string.Empty;
-
-    [ObservableProperty]
-    public partial string Value { get; set; } = string.Empty;
-}

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/TagsEditor.xaml.cs
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/TagsEditor.xaml.cs
@@ -22,8 +22,7 @@ public sealed partial class TagsEditor : UserControl
             nameof(EditableTags),
             typeof(ObservableCollection<TagItem>),
             typeof(TagsEditor),
-            new PropertyMetadata(default(TagsEditor)));
-
+            new PropertyMetadata(null));
     public ObservableCollection<TagItem> EditableTags
     {
         get => (ObservableCollection<TagItem>)GetValue(EditableTagsProperty);
@@ -32,6 +31,9 @@ public sealed partial class TagsEditor : UserControl
 
     private void RemoveTagButton_Click(object sender, RoutedEventArgs e)
     {
+        if (EditableTags is null)
+            return;
+
         if (sender is Button button && button.CommandParameter is TagItem tagItem)
         {
             EditableTags.Remove(tagItem);
@@ -40,6 +42,9 @@ public sealed partial class TagsEditor : UserControl
 
     private void AddTagButton_Click(object sender, RoutedEventArgs e)
     {
+        if (EditableTags is null)
+            EditableTags = [];
+
         EditableTags.Add(new TagItem { Key = string.Empty, Value = string.Empty });
     }
  

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/ViewModels/NewVersionViewModel.cs
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/ViewModels/NewVersionViewModel.cs
@@ -139,8 +139,8 @@ public partial class NewVersionViewModel : ObservableValidator
 
             newSecret.Properties.ContentType = ItemPropertiesModel.ContentType;
 
-            foreach (var tag in ItemPropertiesModel.EditableTags)
-                newSecret.Properties.Tags.Add(tag.Key, tag.Value);
+
+            ItemPropertiesModel.ApplyEditableTags(newSecret.Properties.Tags);
 
             token.ThrowIfCancellationRequested();
 

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/ViewModels/NewVersionViewModel.cs
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/ViewModels/NewVersionViewModel.cs
@@ -16,7 +16,6 @@ public partial class NewVersionViewModel : ObservableValidator
     private readonly IStringLocalizer _localizer;
     public Guid MessengerToken { get; } = Guid.NewGuid();
 
-
     [ObservableProperty]
     public partial TimeSpan ExpiresOnTimespan { get; set; } = TimeSpan.Zero;
 
@@ -61,7 +60,6 @@ public partial class NewVersionViewModel : ObservableValidator
         _authService = services.GetRequiredService<AuthService>();
         _vaultService = services.GetRequiredService<VaultService>();
         _localizer = services.GetRequiredService<IStringLocalizer>();
-
     }
 
     [ObservableProperty]
@@ -97,7 +95,6 @@ public partial class NewVersionViewModel : ObservableValidator
         await dialog.ShowAsync();
     }
 
-
     [RelayCommand]
     public async Task SaveSecretDetailsChanges()
     {
@@ -111,10 +108,17 @@ public partial class NewVersionViewModel : ObservableValidator
         else
             ItemPropertiesModel.ExpiresOn = null;
 
-        var updatedProps = await _vaultService.UpdateSecret(ItemPropertiesModel.ToSecretProperties(), ItemPropertiesModel.VaultUri);
-        ItemPropertiesModel = KeyVaultItemProperties.FromSecretProperties(updatedProps);
+        try
+        {
+            var updatedProps = await _vaultService.UpdateSecret(ItemPropertiesModel.ToSecretProperties(), ItemPropertiesModel.VaultUri);
+            ItemPropertiesModel = KeyVaultItemProperties.FromSecretProperties(updatedProps);
 
-        WeakReferenceMessenger.Default.Send(new ShowSuccessOperationMessage(ItemPropertiesModel.Name, true), MessengerToken);
+            WeakReferenceMessenger.Default.Send(new ShowSuccessOperationMessage(ItemPropertiesModel.Name, true), MessengerToken);
+        }
+        catch (Exception ex)
+        {
+            WeakReferenceMessenger.Default.Send(new ShowValidationErrorMessage(ex.Message), MessengerToken);
+        }
     }
 
     [RelayCommand(FlowExceptionsToTaskScheduler = false, IncludeCancelCommand = true, AllowConcurrentExecutions = false)]
@@ -185,6 +189,4 @@ public partial class NewVersionViewModel : ObservableValidator
             ItemPropertiesModel.ExpiresOn = null;
         }
     }
-
-
 }

--- a/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/ViewModels/NewVersionViewModel.cs
+++ b/src/uno/AzureKeyVaultStudio/AzureKeyVaultStudio/UserControls/ViewModels/NewVersionViewModel.cs
@@ -135,7 +135,7 @@ public partial class NewVersionViewModel : ObservableValidator
 
             newSecret.Properties.ContentType = ItemPropertiesModel.ContentType;
 
-            foreach (var tag in ItemPropertiesModel.Tags)
+            foreach (var tag in ItemPropertiesModel.EditableTags)
                 newSecret.Properties.Tags.Add(tag.Key, tag.Value);
 
             token.ThrowIfCancellationRequested();

--- a/src/uno/AzureKeyVaultStudio/Directory.Packages.props
+++ b/src/uno/AzureKeyVaultStudio/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="Uno.UITest.Helpers" Version="1.1.0-dev.70" />
     <PackageVersion Include="Azure.Core" Version="1.50.0" />
     <PackageVersion Include="Azure.ResourceManager" Version="1.13.2" />
-    <PackageVersion Include="Azure.ResourceManager.KeyVault" Version="1.3.3" />
+    <PackageVersion Include="Azure.ResourceManager.KeyVault" Version="1.4.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Certificates" Version="4.8.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.9.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.9.0" />

--- a/src/uno/AzureKeyVaultStudio/Directory.Packages.props
+++ b/src/uno/AzureKeyVaultStudio/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="10.0.5" />
     <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlcipher" Version="2.1.11" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.83.1" />
+    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.83.3" />
     <PackageVersion Include="DeviceId" Version="6.11.0" />
     <PackageVersion Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.2.251219" />
     <PackageVersion Include="CommunityToolkit.WinUI.Controls.Segmented" Version="8.2.251219" />

--- a/src/uno/global.json
+++ b/src/uno/global.json
@@ -1,7 +1,7 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "6.6.0-dev.148"
+    "Uno.Sdk": "6.6.0-dev.156"
   },
   "sdk": {
     "allowPrerelease": false

--- a/src/uno/global.json
+++ b/src/uno/global.json
@@ -1,7 +1,7 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "6.6.0-dev.156"
+    "Uno.Sdk": "6.6.0-dev.162"
   },
   "sdk": {
     "allowPrerelease": false


### PR DESCRIPTION
## Add tag editing support
Closes #100 
- Add UI support for adding, editing, and removing tags on secrets, and updated localization. 
- Add EditableTags property and TagsEditor control
- bump to version 2.1.0
- Use itemsrepeater rather than items control
- Update tags accent color so you can see what youre highlighting
- Use toolkits layout so tags collapse and expand uniformly 


<img width="1086" height="633" alt="image" src="https://github.com/user-attachments/assets/fcf38a17-7e84-4b8d-a621-c009694173e7" />

<img width="606" height="573" alt="image" src="https://github.com/user-attachments/assets/f938adc7-33d0-4f7b-8ed6-283c63949527" />


<img width="1079" height="919" alt="image" src="https://github.com/user-attachments/assets/50cfb28f-5a12-4010-849e-e4a5c984e7fe" />

![Recording 2026-03-31 082201](https://github.com/user-attachments/assets/c596ed14-c074-41a5-81d7-c630ee389ed5)
<img width="1036" height="664" alt="image" src="https://github.com/user-attachments/assets/3e0cc046-37b6-4b3c-a0e9-da1eb3e14e5d" />

